### PR TITLE
Update Wenjia's user_groups setting

### DIFF
--- a/content/authors/wenjia-ye/_index.md
+++ b/content/authors/wenjia-ye/_index.md
@@ -66,7 +66,7 @@ email: ""
 # Organizational groups that you belong to (for People widget)
 #   Set this to `[]` or comment out if you are not using People widget.
 user_groups:
-- Research Fellow
+- Research Fellows
 ---
 
 Find more information about [Wenjia](https://YeWenjia.github.io/).


### PR DESCRIPTION
Update Wenjia's `user_groups` setting to `Research Fellows` to match the previous update. 